### PR TITLE
Fix null-keyword error in code

### DIFF
--- a/src/IsScrolled.ts
+++ b/src/IsScrolled.ts
@@ -16,7 +16,7 @@ class IsScrolled {
   }
 
   updateClass = (): void => {
-    const target: Element | null = document.querySelector(this.targetSelector);
+    const target = document.querySelector(this.targetSelector);
     if (target) {
       if (window.scrollY >= this.scrollThreshold) {
         target.classList.add(this.className);
@@ -57,7 +57,7 @@ class IsScrolled {
 
   destroy(): void {
     this.pause();
-    const target: Element | null = document.querySelector(this.targetSelector);
+    const target = document.querySelector(this.targetSelector);
     if (target) {
       target.classList.remove(this.className);
     }


### PR DESCRIPTION
Remove explicit `| null` type annotations to resolve `null-keyword` ESLint error.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d37544a-1b0a-4ead-a86b-585b11796eea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7d37544a-1b0a-4ead-a86b-585b11796eea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>